### PR TITLE
Add Makefile and test target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /bog-autoloads.el
+
+# Needed for `make test`
+.downloads
+dash.el

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+EMACS := emacs
+CURL := curl --silent
+
+DASH_URL := https://raw.githubusercontent.com/magnars/dash.el/master/dash.el
+
+.PHONY: test
+
+test: .downloads
+	${EMACS} -Q --batch -L . \
+		-l bog-tests \
+		--eval "(ert-run-tests-batch-and-exit '(not (tag interactive)))"
+
+.downloads:
+	${CURL} ${DASH_URL} > dash.el
+	touch .downloads
+
+clean:
+	@rm -rf maven-test-mode-*/ maven-test-mode-*.tar *.elc

--- a/bog-todo
+++ b/bog-todo
@@ -56,7 +56,7 @@ extensions (or maybe just take the extension from the original file).
 
 * Testing
 
-** ENH Ability to run tests from makefile
+** DONE Ability to run tests from makefile
 
 ** DONE Put some of the common setup in macros
 


### PR DESCRIPTION
As I've done this very recently in a minor mode I made, I decided to help with the Makefile thing.

Also, setting up travis CI is astonishingly easy. If you're interested, probably a copy of this file [.travis.yml](https://github.com/rranelli/maven-test-mode/blob/master/.travis.yml) will suffice.
