### PR TITLE
Use HTTPS URLs where applicable

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,9 +3,9 @@
 #+startup: showall
 
 [[https://travis-ci.org/kyleam/bog][https://travis-ci.org/kyleam/bog.svg]]
-[[http://melpa.org/#/bog][http://melpa.org/packages/bog-badge.svg]]
+[[https://melpa.org/#/bog][https://melpa.org/packages/bog-badge.svg]]
 
-Bog is a system for taking research notes in [[http://orgmode.org/][Org mode]].  It adds a few
+Bog is a system for taking research notes in [[https://orgmode.org/][Org mode]].  It adds a few
 research-specific features, nearly all of which are focused on managing
 and taking notes with Org, not on writing research articles with Org.
 

--- a/bog-tests.el
+++ b/bog-tests.el
@@ -15,7 +15,7 @@
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Code:
 

--- a/bog.el
+++ b/bog.el
@@ -19,7 +19,7 @@
 ;; GNU General Public License for more details.
 ;;
 ;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;;
@@ -202,7 +202,7 @@ character should be a non-word character according to
   :package-version '(bog . "1.3.0"))
 
 (defcustom bog-web-search-url
-  "http://scholar.google.com/scholar?q=%s"
+  "https://scholar.google.com/scholar?q=%s"
   "URL to use for CITEKEY search.
 It should contain the placeholder \"%s\" for the query."
   :type 'string)


### PR DESCRIPTION
The only remaining HTTP links either point to Gmane, which doesn't seem to support HTTPS, or reside under `example/`.