### PR TITLE
Replace deprecated org-show-context

### DIFF
--- a/bog.el
+++ b/bog.el
@@ -1,7 +1,7 @@
 ;;; bog.el --- Extensions for research notes in Org mode -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013-2016 Kyle Meyer <kyle@kyleam.com>
-;; Copyright (C) 2020 Basil L. Contovounesios <contovob@tcd.ie>
+;; Copyright (C) 2020-2023 Basil L. Contovounesios <contovob@tcd.ie>
 
 ;; Author: Kyle Meyer <kyle@kyleam.com>
 ;; URL: https://github.com/kyleam/bog
@@ -1032,6 +1032,12 @@ Groups are specified by `bog-citekey-web-search-groups'."
 
 ;;; Notes-related
 
+;; `org-show-context' is obsolete as of Org 9.6.
+(defalias 'bog--fold-show-context
+  (if (fboundp 'org-fold-show-context)
+      #'org-fold-show-context
+    'org-show-context))
+
 ;;;###autoload
 (defun bog-goto-citekey-heading-in-notes (&optional no-context)
   "Find citekey heading in notes.
@@ -1062,7 +1068,7 @@ buffer, the narrowing is removed."
                 (> marker (point-max)))
         (widen))
       (goto-char marker)
-      (org-show-context))))
+      (bog--fold-show-context))))
 
 (defun bog--find-citekey-heading-in-buffer (citekey &optional pos-only)
   "Return the marker of heading for CITEKEY.
@@ -1332,7 +1338,7 @@ With argument ARG, do it ARG times."
                     (re-search-forward bog-citekey-format nil t))
           (unless (org-at-heading-p)
             (setq arg (1- arg))))))
-    (org-show-context)))
+    (bog--fold-show-context)))
 
 ;;;###autoload
 (defun bog-previous-non-heading-citekey (&optional arg)
@@ -1347,7 +1353,7 @@ With argument ARG, do it ARG times."
         (unless (org-at-heading-p)
           (setq arg (1- arg)))))
     (skip-syntax-backward "w"))
-  (org-show-context))
+  (bog--fold-show-context))
 
 ;;;###autoload
 (defun bog-jump-to-topic-heading ()


### PR DESCRIPTION
With Emacs `HEAD`:

```
make clean all test
rm -f bog.elc bog-autoloads.el bog-tests.elc

In bog-goto-citekey-heading-in-notes:
bog.el:1065:8: Warning: ‘org-show-context’ is an obsolete function (as of 9.6); use ‘org-fold-show-context’ instead.

In bog-next-non-heading-citekey:
bog.el:1335:6: Warning: ‘org-show-context’ is an obsolete function (as of 9.6); use ‘org-fold-show-context’ instead.

In bog-previous-non-heading-citekey:
bog.el:1350:4: Warning: ‘org-show-context’ is an obsolete function (as of 9.6); use ‘org-fold-show-context’ instead.
[...]
```

This pacifies the warnings:

* `bog.el`: Update copyright years.
(`bog--fold-show-context`): New compatibility shim for `org-show-context`, deprecated alias of `org-fold-show-context` new in Org 9.6 / Emacs 29.
(`bog-goto-citekey-heading-in-notes`, `bog-next-non-heading-citekey`)
(`bog-previous-non-heading-citekey`): Use it in place of `org-show-context`.